### PR TITLE
Chore/add poppler

### DIFF
--- a/macaw-base-image.dockerfile
+++ b/macaw-base-image.dockerfile
@@ -5,7 +5,7 @@ ENV CHROME_DRIVER_VERSION 2.35
 ENV SELENIUM_STANDALONE_VERSION 3.8.1
 
 LABEL maintainer="Arcadia Power Engineering <engineering@arcadiapower.com>" \
-      version="0.3" \
+      version="0.4" \
       description="Ubuntu Ruby 2.4.4 base image for Macaw Scrapers"
 
 RUN apt-get -y update \
@@ -37,6 +37,7 @@ RUN apt-get -y update \
     nodejs \
     unzip \
     wget \
+    xpdf \
     xvfb \
  && locale-gen en_US.UTF-8 \
  && apt-get clean \

--- a/macaw-base-image.dockerfile
+++ b/macaw-base-image.dockerfile
@@ -31,6 +31,7 @@ RUN apt-get -y update \
     libxslt1-dev \
     libyaml-dev \
     locales \
+    poppler-utils \
     tesseract-ocr \
     imagemagick \
     ghostscript \


### PR DESCRIPTION
This is needed for running the new `PdfToText` library, used to start with national grid because we can't get load zone otherwise - https://github.com/ArcadiaPower/utility-scrapers/pull/741/files

## Risks

Tested locally with building the image and running on macaw with `bin/local-start.sh`. Got to work creating a new statement for account 143956 (there are some intermittent popups if you are testing with national grid). Load zone doesn't get populated yet in database, but it was in the parameters returned.

Please let me know what needs to be done with regard to pushing image / changing version on macaw Dockerfile, etc.